### PR TITLE
Fixed tests and added support for mpi4py version 3

### DIFF
--- a/neurokernel/mpi.py
+++ b/neurokernel/mpi.py
@@ -320,7 +320,7 @@ if __name__ == '__main__':
     # Define a class whose constructor takes arguments so as to test
     # instantiation of the class by the manager:
     class MyWorker(Worker):
-        def __init__(self, x, y, z=None):
+        def __init__(self, x, y, z=None, routing_table=None):
             super(MyWorker, self).__init__()
             name = MPI.Get_processor_name()
             self.log_info('I am process %d of %d on %s.' % (self.rank,

--- a/neurokernel/mpi_backend.py
+++ b/neurokernel/mpi_backend.py
@@ -33,14 +33,19 @@ import atexit
 import twiggy
 from mpi4py import MPI
 
-# The MPI._p_pickle attribute in the stable release of mpi4py 1.3.1
-# was renamed to pickle in subsequent dev revisions:
+# mpi4py has changed the method to override pickle with dill various times
 try:
-    MPI.pickle.dumps = dill.dumps
-    MPI.pickle.loads = dill.loads
+    # mpi4py 3.0.0
+    MPI.pickle.__init__(dill.dumps, dill.loads)
 except AttributeError:
-    MPI._p_pickle.dumps = dill.dumps
-    MPI._p_pickle.loads = dill.loads
+    try:
+        # mpi4py versions 1.3.1 through 2.x
+        MPI.pickle.dumps = dill.dumps
+        MPI.pickle.loads = dill.loads
+    except AttributeError:
+        # mpi4py pre 1.3.1
+        MPI._p_pickle.dumps = dill.dumps
+        MPI._p_pickle.loads = dill.loads
 
 # This import must match the corresponding import in neurokernel.tools.logging
 # so that the isinstance() check below for MPIOutput instances in transmitted

--- a/neurokernel/mpi_run.py
+++ b/neurokernel/mpi_run.py
@@ -2,8 +2,13 @@ import tempfile
 import os
 import inspect
 import subprocess
+import dill
+import re
 
-def mpi_run(func):
+from neurokernel.mixins import LoggerMixin
+
+def mpi_run(func, targets=None, delete_tempfile=True, log=True,
+            log_screen=True, log_file_name='neurokernel.log'):
     """
     Run a function with mpiexec.
     
@@ -26,50 +31,143 @@ def mpi_run(func):
 
     Usage
     -----
+    This will only work when the target class is in a library (like LPU),
+        if the source for the class is in the source file it will not work. This
+        can be extended to be more general if anyone has a use for it.
     Does not seem to work with openmpi version 2
     func should not import neurokernel.mpi_relaunch
     All modules and variables used must be imported or defined within func
     Returns the stdout from the function run under 'mpiexec -np 1 python {tmp_file_name}'
     """
+
+    l = LoggerMixin("mpi_run()",log_on=log)
     
-    #Create a temporary file
-    temp, filename = tempfile.mkstemp()
+    if callable(func):
+        func_text = inspect.getsource(func)
+        # Make a feeble attempt at fixing indentation. Will work for a nested function
+        # that takes no args, not a member function that expects (self) or a class
+        func_text = "\n" + re.sub(r"(^\s+)def ","def ",func_text) + "\n"
+        func_name = func.__name__
+    else: 
+        func_text = "\n" + func + "\n"
+        func_name = re.search('def *(.*)\(\):', func_text).group(1)
+
+    target_text  = "\n"
     
-    #Write code from func into the file
-    os.write(temp, inspect.getsource(func))
+    if targets:
+        for t in targets:
+            target_text +=  "\n" + inspect.getsource(t) + "\n"
+
+    main_code  = "\n"
+    main_code += "\nif __name__ == \"__main__\":"
+    main_code += "\n   import neurokernel.mpi as mpi"
+    main_code += "\n   from neurokernel.mixins import LoggerMixin"
+    main_code += "\n   from mpi4py import MPI"
+
+    if log:
+        main_code += "\n   mpi.setup_logger(screen=%s, file_name=\"%s\"," % (log_screen, log_file_name)
+        main_code += "\n                    mpi_comm=MPI.COMM_WORLD, multiline=True)"
+
+    main_code += "\n   l = LoggerMixin(\"%s\",%s)" % (func_name,str(log))
+    main_code += "\n   try:"
+    main_code += "\n      %s()" % func_name
+    main_code += "\n      print(\"MPI_RUN_SUCCESS: %s\")" % func_name
+    main_code += "\n      l.log_info(\"MPI_RUN_SUCCESS: %s\")" % func_name
+    main_code += "\n   except Exception as e:"
+    main_code += "\n      print(\"MPI_RUN_FAILURE: %s\")" % func_name
+    main_code += "\n      l.log_error(\"MPI_RUN_FAILURE: %s\")" % func_name
+    main_code += "\n      print(e)"
+    main_code += "\n"
+
+    try:
+        #Write code for the function to a temp file
+        temp = tempfile.NamedTemporaryFile(delete = delete_tempfile)
+        temp.write(target_text)
+        temp.write(func_text)
+        temp.write(main_code)
+        temp.flush()
+        
+        #Execute the code
+        env = os.environ.copy()
+        command = ["mpiexec", "-np", "1", "python", temp.name]
+        l.log_info("Calling: " + " ".join(command))
+        out = subprocess.check_output(command, env = env)
+
+    except Exception as e:
+        l.log_error(str(e))
+        raise
+
+    finally:    
+        #Closing the temp file closes and deletes it
+        temp.close()
     
-    #Add a main
-    os.write(temp, "\nif __name__ == \"__main__\":")
-    os.write(temp, "\n   try:")
-    os.write(temp, "\n      %s()" % func.__name__)
-    os.write(temp, "\n      print(\"%s executed successfully\")" % func.__name__)
-    os.write(temp, "\n   except Exception as e:")
-    os.write(temp, "\n      print(\"%s failed\")" % func.__name__) 
-    os.write(temp, "\n      print(e)")
-    
-    #Extract the current environment
-    env = os.environ.copy()
-    
-    #Execute the code
-    out = subprocess.check_output(["mpiexec", "-np", "1", "python", filename], env = env)
-    
-    #Close the file
-    os.close(temp)
+    #Return the output
+    if "MPI_RUN_FAILURE" in out:
+        raise RuntimeError(out)
+
+    return str(out)
+
+
+def mpi_run_manager(man, steps, targets=None, delete_tempfile=True, log=True,
+                    log_screen=True, log_file_name='neurokernel.log'):
+    """
+    Run the manager with mpiexec.
+    """
+
+    l = LoggerMixin("mpi_run_manager()",log_on=log)
+
+    #Write a function that loads and runs the Manager
+    func_code  = "\ndef MPI_Function():"
+    func_code += "\n    import dill"
+    func_code += "\n    f = open(\"%s\",\"rb\")"
+    func_code += "\n    man = dill.load(f)"
+    func_code += "\n    man.spawn()" 
+    func_code += "\n    man.start(steps=%i)"
+    func_code += "\n    man.wait()"
+
+    try:
+        #Store the Manager in a temporary file
+        temp = tempfile.NamedTemporaryFile(delete = delete_tempfile)
+        dill.dump(man, temp)
+        temp.flush()
+        
+        #Run the function using mpiexec
+        out = mpi_run(func_code % (temp.name,steps), targets, 
+                      delete_tempfile=delete_tempfile, log=log,
+                      log_screen=log_screen, log_file_name=log_file_name)
+
+    except Exception as e:
+        l.log_error(str(e))
+        raise
+
+    finally:    
+        #Closing the temp file closes and deletes it
+        temp.close()
     
     #Return the output
     return str(out)
 
-def _test_success(): 
-  print("HELLO WORLD")
 
-def _test_fail(): 
-  open("RANDOM_FILE", "r").read() 
-
-#A test for the function
+#Basic sanity checks
 if __name__ == "__main__":
 
-   print("This should succeed:")
-   print(mpi_run(_test_success))
+    from tools.logging import setup_logger
+    setup_logger(screen=True, file_name='neurokernel.log', multiline=True)
 
-   print("This should fail:")
-   print(mpi_run(_test_fail))
+    def _test_success(): 
+        print("HELLO WORLD")
+
+    def _test_fail(): 
+        open("RANDOM_FILE", "r").read() 
+
+    print("This should succeed:")
+    print(mpi_run(_test_success))
+
+    print("This should also succeed:")
+    code  = "\ndef func():"
+    code += "\n   print(\"HELLO AGAIN\")"
+    print(mpi_run(code))
+
+    print("This should fail:")
+    print(mpi_run(_test_fail))
+

--- a/neurokernel/mpi_run.py
+++ b/neurokernel/mpi_run.py
@@ -1,0 +1,75 @@
+import tempfile
+import os
+import inspect
+import subprocess
+
+def mpi_run(func):
+    """
+    Run a function with mpiexec.
+    
+    Implemented as a fix to 'import neurokernel.mpi_relaunch', which does not
+    work within notebooks. Writes the source code for a function to a temporary
+    file and then runs the temporary file using mpiexec. Returns the stdout of
+    from the function along with a string indicating whether or not the function
+    executed properly.
+
+    Parameters
+    ----------
+    func : function
+        Function to be executed with mpiexec. All imports and variables used
+        must be imported or defined within the function.
+    
+    Returns
+    -------
+    output : str
+        The stdout from the function run with mpiexec cast to a string.
+
+    Usage
+    -----
+    Does not seem to work with openmpi version 2
+    func should not import neurokernel.mpi_relaunch
+    All modules and variables used must be imported or defined within func
+    Returns the stdout from the function run under 'mpiexec -np 1 python {tmp_file_name}'
+    """
+    
+    #Create a temporary file
+    temp, filename = tempfile.mkstemp()
+    
+    #Write code from func into the file
+    os.write(temp, inspect.getsource(func))
+    
+    #Add a main
+    os.write(temp, "\nif __name__ == \"__main__\":")
+    os.write(temp, "\n   try:")
+    os.write(temp, "\n      %s()" % func.__name__)
+    os.write(temp, "\n      print(\"%s executed successfully\")" % func.__name__)
+    os.write(temp, "\n   except Exception as e:")
+    os.write(temp, "\n      print(\"%s failed\")" % func.__name__) 
+    os.write(temp, "\n      print(e)")
+    
+    #Extract the current environment
+    env = os.environ.copy()
+    
+    #Execute the code
+    out = subprocess.check_output(["mpiexec", "-np", "1", "python", filename], env = env)
+    
+    #Close the file
+    os.close(temp)
+    
+    #Return the output
+    return str(out)
+
+def _test_success(): 
+  print("HELLO WORLD")
+
+def _test_fail(): 
+  open("RANDOM_FILE", "r").read() 
+
+#A test for the function
+if __name__ == "__main__":
+
+   print("This should succeed:")
+   print(mpi_run(_test_success))
+
+   print("This should fail:")
+   print(mpi_run(_test_fail))

--- a/neurokernel/plsel.py
+++ b/neurokernel/plsel.py
@@ -1831,7 +1831,7 @@ class SelectorMethods(SelectorParser):
                 names = range(max_levels)
 
             if selectors == ((),):
-                return pd.MultiIndex(levels=[[]], labels=[[]], names=names)
+                return pd.MultiIndex(levels=[[]], labels=[[]], names=[0])
             else:
                 return pd.MultiIndex.from_tuples(selectors, names=names)
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -77,10 +77,10 @@ class MyModule2(Module):
         self.out_buf.append(in_spike_data)
 
     def post_run(self):
-        super(MyModule2, self).post_run()
         if self.out_file_name:
             with open(self.out_file_name, 'w') as f:
                 pickle.dump(self.out_buf[1], f)
+        super(MyModule2, self).post_run()
 
 def make_sels(sel_in_gpot, sel_out_gpot, sel_in_spike, sel_out_spike):
     sel_in_gpot = Selector(sel_in_gpot)

--- a/tests/test_core_gpu.py
+++ b/tests/test_core_gpu.py
@@ -80,10 +80,10 @@ class MyModule2(Module):
         self.out_buf.append(in_spike_data)
 
     def post_run(self):
-        super(MyModule2, self).post_run()
         if self.out_file_name:
             with open(self.out_file_name, 'w') as f:
                 pickle.dump(self.out_buf[1], f)
+        super(MyModule2, self).post_run()
 
 def make_sels(sel_in_gpot, sel_out_gpot, sel_in_spike, sel_out_spike):
     sel_in_gpot = Selector(sel_in_gpot)

--- a/tests/test_mixins.py
+++ b/tests/test_mixins.py
@@ -37,11 +37,11 @@ class test_loggermixin(TestCase):
 
         # All output to stdout is buffered within a single test before emission:
         self.assertEquals(sys.stdout.getvalue().strip(),
-                          'log:DEBUG:abc\n'
-                          'log:INFO:abc\n'
-                          'log:WARNING:abc\n'
-                          'log:ERROR:abc\n'
-                          'log:CRITICAL:abc')
+                          'log:DEBUG|abc\n'
+                          'log:INFO|abc\n'
+                          'log:WARNING|abc\n'
+                          'log:ERROR|abc\n'
+                          'log:CRITICAL|abc')
 
     def test_log_on(self):
         self.lm.log_on = False

--- a/tests/test_mpi_proc.py
+++ b/tests/test_mpi_proc.py
@@ -13,39 +13,23 @@ from mpi4py import MPI
 
 from neurokernel.mpi_proc import Process, ProcessManager
 
-class MyProc(Process):
-    def run(self):
-        self.send_parent('%s %s %s' % (self.rank, str(self._args), 
-                                       str(self._kwargs)))
+import logging
 
-def myfunc(*args, **kwargs):
-    rank = MPI.COMM_WORLD.Get_rank()
-    MPI.Comm.Get_parent().send('%s %s %s' % (rank, str(args), str(kwargs)), 0)
+class MyProc(Process):
+    def __init__(self, a, b, c, routing_table=None):
+        super(MyProc, self).__init__()
+        self.response = "a=%s b=%s c=%s" % (a,b,c)
+
+    def run(self):
+        self.send_parent(self.response)
 
 class test_mpi_proc(TestCase):
     def test_process(self):
         man = ProcessManager()
-        man.add(MyProc, 'x', 'y', z=1)
-        man.add(MyProc, 'a', 'b', c=2)
-        man.run()
-        results = []
-        results.append(man.recv())
-        results.append(man.recv())
-        self.assertItemsEqual(results, 
-                              ["0 ('x', 'y') {'z': 1}",
-                               "1 ('a', 'b') {'c': 2}"])
-
-    def test_func(self):
-        man = ProcessManager()
-        man.add(myfunc, 'x', 'y', z=1)
-        man.add(myfunc, 'a', 'b', c=2)
-        man.run()
-        results = []
-        results.append(man.recv())
-        results.append(man.recv())
-        self.assertItemsEqual(results, 
-                              ["0 ('x', 'y') {'z': 1}",
-                               "1 ('a', 'b') {'c': 2}"])
+        man.add(MyProc, 'x', 'y', c=1)
+        man.spawn()
+        results=man.recv()
+        self.assertEqual(results,'a=x b=y c=1')
     
 if __name__ == '__main__':
     main()

--- a/tests/test_mpi_run.py
+++ b/tests/test_mpi_run.py
@@ -1,0 +1,194 @@
+#!/usr/bin/env python
+
+#import neurokernel.mpi_relaunch
+import cPickle as pickle
+import os
+import tempfile
+
+from mpi4py import MPI
+import numpy as np
+import pycuda.gpuarray as gpuarray
+
+from neurokernel.pattern import Pattern
+from neurokernel.plsel import Selector, SelectorMethods
+from neurokernel.core_gpu import Module, Manager, CTRL_TAG, GPOT_TAG, SPIKE_TAG
+import neurokernel.mpi as mpi
+from neurokernel.mpi_run import mpi_run,mpi_run_manager
+
+import warnings
+warnings.simplefilter("ignore")
+
+class MyModule1(Module):
+    """
+    Module that emits data.
+    """
+
+    def __init__(self, sel, sel_in, sel_out,
+                 sel_gpot, sel_spike, data_gpot, data_spike,
+                 columns=['interface', 'io', 'type'],
+                 ctrl_tag=CTRL_TAG, gpot_tag=GPOT_TAG, spike_tag=SPIKE_TAG,
+                 id=None, device=None,
+                 routing_table=None, rank_to_id=None,
+                 debug=False, time_sync=False, out_spike_data=None):
+        super(MyModule1, self).__init__(sel, sel_in, sel_out,
+                 sel_gpot, sel_spike, data_gpot, data_spike,
+                 columns,
+                 ctrl_tag, gpot_tag, spike_tag,
+                 id, device,
+                 routing_table, rank_to_id,
+                 debug, time_sync)
+        self.out_spike_data = out_spike_data
+
+    def run_step(self):
+        super(MyModule1, self).run_step()
+
+        # Emit data by setting elements in port map data array corresponding to
+        # output ports:
+        if self.out_spike_data:
+            out_spike_data_gpu = gpuarray.to_gpu(np.asarray(self.out_spike_data,
+                                                        self.data['spike'].dtype))
+            self.pm['spike'][self.out_spike_ports] = out_spike_data_gpu
+            self.log_info('output spike port data: ' + str(out_spike_data_gpu))
+
+class MyModule2(Module):
+    """
+    Module that expects data.
+    """
+
+    def __init__(self, sel, sel_in, sel_out,
+                 sel_gpot, sel_spike, data_gpot, data_spike,
+                 columns=['interface', 'io', 'type'],
+                 ctrl_tag=CTRL_TAG, gpot_tag=GPOT_TAG, spike_tag=SPIKE_TAG,
+                 id=None, device=None,
+                 routing_table=None, rank_to_id=None,
+                 debug=False, time_sync=False, out_file_name=None):
+        super(MyModule2, self).__init__(sel, sel_in, sel_out,
+                 sel_gpot, sel_spike, data_gpot, data_spike,
+                 columns,
+                 ctrl_tag, gpot_tag, spike_tag,
+                 id, device,
+                 routing_table, rank_to_id,
+                 debug, time_sync)
+        self.out_file_name = out_file_name
+            
+    out_buf = []
+
+    def run_step(self):
+        super(MyModule2, self).run_step()
+
+        # Save received data by recording elements in port map data array
+        # corresponding to input ports:
+        in_spike_data = self.pm['spike'][self.in_spike_ports]
+        self.log_info('input spike port data: '+str(in_spike_data))
+        self.out_buf.append(in_spike_data)
+
+    def post_run(self):
+        import cPickle as pickle
+        if self.out_file_name:
+            with open(self.out_file_name, 'w') as f:
+                pickle.dump(self.out_buf[1], f)
+
+        super(MyModule2, self).post_run()
+
+def test_success(): 
+    print("HELLO WORLD")
+
+def make_sels(sel_in_gpot, sel_out_gpot, sel_in_spike, sel_out_spike):
+    sel_in_gpot = Selector(sel_in_gpot)
+    sel_out_gpot = Selector(sel_out_gpot)
+    sel_in_spike = Selector(sel_in_spike)
+    sel_out_spike = Selector(sel_out_spike)
+
+    sel = sel_in_gpot+sel_out_gpot+sel_in_spike+sel_out_spike
+    sel_in = sel_in_gpot+sel_in_spike
+    sel_out = sel_out_gpot+sel_out_spike
+    sel_gpot = sel_in_gpot+sel_out_gpot
+    sel_spike = sel_in_spike+sel_out_spike
+    
+    return sel, sel_in, sel_out, sel_gpot, sel_spike
+
+from unittest import main, TestCase
+
+debug = True
+
+class test_mpi_run(TestCase):
+
+    def test_mpi_run_manager(self):
+        man = Manager()
+        m1_sel_in_gpot = Selector('')
+        m1_sel_out_gpot = Selector('')
+        m1_sel_in_spike = Selector('')
+        m1_sel_out_spike = Selector('/m1/out/spike[0:4]')
+        m1_sel, m1_sel_in, m1_sel_out, m1_sel_gpot, m1_sel_spike = \
+            make_sels(m1_sel_in_gpot, m1_sel_out_gpot, m1_sel_in_spike, m1_sel_out_spike)
+        N1_gpot = SelectorMethods.count_ports(m1_sel_gpot)
+        N1_spike = SelectorMethods.count_ports(m1_sel_spike)
+
+        m2_sel_in_gpot = Selector('')
+        m2_sel_out_gpot = Selector('')
+        m2_sel_in_spike = Selector('/m2/in/spike[0:4]')
+        m2_sel_out_spike = Selector('')
+        m2_sel, m2_sel_in, m2_sel_out, m2_sel_gpot, m2_sel_spike = \
+            make_sels(m2_sel_in_gpot, m2_sel_out_gpot, m2_sel_in_spike, m2_sel_out_spike)
+        N2_gpot = SelectorMethods.count_ports(m2_sel_gpot)
+        N2_spike = SelectorMethods.count_ports(m2_sel_spike)
+
+        m1_id = 'm1'
+        man.add(MyModule1, m1_id,
+                     m1_sel, m1_sel_in, m1_sel_out,
+                     m1_sel_gpot, m1_sel_spike,
+                     np.zeros(N1_gpot, dtype=np.double),
+                     np.zeros(N1_spike, dtype=int),
+                     device=0, debug=debug, out_spike_data=[1, 0, 1, 0])
+
+        f, out_file_name = tempfile.mkstemp()
+        os.close(f)
+
+        m2_id = 'm2'
+        man.add(MyModule2, m2_id,
+                     m2_sel, m2_sel_in, m2_sel_out,
+                     m2_sel_gpot, m2_sel_spike,
+                     np.zeros(N2_gpot, dtype=np.double),
+                     np.zeros(N2_spike, dtype=int),
+                     device=1, debug=debug, out_file_name=out_file_name)
+
+        pat12 = Pattern(m1_sel, m2_sel)
+        pat12.interface[m1_sel_out_gpot] = [0, 'in', 'gpot']
+        pat12.interface[m1_sel_in_gpot] = [0, 'out', 'gpot']
+        pat12.interface[m1_sel_out_spike] = [0, 'in', 'spike']
+        pat12.interface[m1_sel_in_spike] = [0, 'out', 'spike']
+        pat12.interface[m2_sel_in_gpot] = [1, 'out', 'gpot']
+        pat12.interface[m2_sel_out_gpot] = [1, 'in', 'gpot']
+        pat12.interface[m2_sel_in_spike] = [1, 'out', 'spike']
+        pat12.interface[m2_sel_out_spike] = [1, 'in', 'spike']
+        pat12['/m1/out/spike[0]', '/m2/in/spike[0]'] = 1
+        pat12['/m1/out/spike[1]', '/m2/in/spike[1]'] = 1
+        pat12['/m1/out/spike[2]', '/m2/in/spike[2]'] = 1
+        pat12['/m1/out/spike[3]', '/m2/in/spike[3]'] = 1
+        man.connect(m1_id, m2_id, pat12, 0, 1)
+
+        # Run emulation for 2 steps:
+        output = mpi_run_manager(man,2)
+        print(output)
+
+        # Get output of m2:
+        with open(out_file_name, 'r') as f:
+            output = pickle.load(f)
+
+        os.remove(out_file_name)
+        self.assertSequenceEqual(list(output), [1, 0, 1, 0])
+
+    def test_mpi_run(self):
+        output = mpi_run(test_success)
+        self.assertTrue("HELLO WORLD" in output)
+
+    def test_mpi_run_code(self):
+        code  = "\ndef func():"
+        code += "\n   print(\"HELLO AGAIN\")"
+        output = mpi_run(code)
+        self.assertTrue("HELLO AGAIN" in output)
+
+if __name__ == '__main__':
+    logger = mpi.setup_logger(screen=True,
+                              mpi_comm=MPI.COMM_WORLD, multiline=True)
+    main()

--- a/tests/test_plsel.py
+++ b/tests/test_plsel.py
@@ -549,16 +549,16 @@ class test_path_like_selector(TestCase):
 
     def test_make_index_empty(self):
         idx = self.sel.make_index('')
-        assert_index_equal(idx, pd.Index([], dtype='object'))
+        assert_index_equal(idx, pd.MultiIndex(levels=[[]], labels=[[]], names=[0]))
 
         idx = self.sel.make_index(Selector(''))
-        assert_index_equal(idx, pd.Index([], dtype='object'))
+        assert_index_equal(idx, pd.MultiIndex(levels=[[]], labels=[[]], names=[0]))
 
     def test_make_index_str_single_level(self):
         idx = self.sel.make_index('/foo')
-        assert_index_equal(idx, pd.Index(['foo'], name=0, dtype='object'))
+        assert_index_equal(idx, pd.MultiIndex([['foo']], labels=[[0]], names=[0]))
         idx = self.sel.make_index('/foo,/bar')
-        assert_index_equal(idx, pd.Index(['foo', 'bar'], name=0, dtype='object'))
+        assert_index_equal(idx, pd.MultiIndex([['foo', 'bar']], labels=[[0,1]], names=[0]))
 
     def test_make_index_str_multiple_levels(self):
         idx = self.sel.make_index('/[foo,bar]/[0:3]')
@@ -578,9 +578,9 @@ class test_path_like_selector(TestCase):
 
     def test_make_index_list_single_level(self):
         idx = self.sel.make_index([['foo']])
-        assert_index_equal(idx, pd.Index(['foo'], name=0, dtype='object'))
+        assert_index_equal(idx, pd.MultiIndex([['foo']], labels=[[0]], names=[0]))
         idx = self.sel.make_index([['foo'], ['bar']])
-        assert_index_equal(idx, pd.Index(['foo', 'bar'], name=0, dtype='object'))
+        assert_index_equal(idx, pd.MultiIndex([['foo', 'bar']], labels=[[0,1]], names=[0]))
 
     def test_make_index_list_multiple_levels(self):
         idx = self.sel.make_index([[['foo', 'bar'], slice(0, 3)]])

--- a/tests/test_pm.py
+++ b/tests/test_pm.py
@@ -134,8 +134,9 @@ class test_port_mapper(TestCase):
         # indexes with dtype=object):
         pm = PortMapper('')
         assert_series_equal(pm.portmap,
-            pd.Series([], dtype=np.int_, index=pd.Index([], object)))
+            pd.Series([], dtype=np.int_, index=pd.MultiIndex(levels=[[]], labels=[[]], names=[0])))
         assert_array_equal(pm.data, np.array([]))
+
 
         # Non-empty selector, empty data:
         pm = PortMapper('/foo[0:3]')


### PR DESCRIPTION
Made changes to fix both inline tests in ./neurokernel and unit tests in ./tests. Made changes to support mpi4py v3.0.0 and ran all tests to validate implementation. 

./neurokernel/core_gpu.py
Many tests assume the machine you're on has more than one GPU. This will not always be
true. When a GPU that doesn't exist is specified, assign a device that does exist at
random.

./neurokernel/mpi.py
The inline tests for mpi.py and mpi_proc.py need a routing table. For an __init__ with
named arguments routing_table needs to be included in the arguments or it won't be sent
to the mpi_backend

./neurokernel/mpi_backend.py
mpi4py has again changed the way to override pickle with dill in version 3.0.0
This change allows us to support version 3.0.0 of mpi4py along with previous versions

./neurokernel/mpi_proc.py
1) mpi4py has again changed the way to override pickle with dill in version 3.0.0 
   This change allows us to support version 3.0.0 of mpi4py along with previous versions

2) The inline tests in mpi.py and mpi_proc.py need a routing_table. If one does not exist
   issue a warning and create an empty RoutingTable(). This should only be necessary
   for the tests, or if someone extends mpi.Worker or mpi_proc.Process instead of
   extending core_gpu.Module for some reason.

./neurokernel/plsel.py
The specified MultiIndex for empty selector has one level. There needs to be one name
for an empty Selector('').     

./tests/test_core_gpu.py
There was a race condition where the post_run method would tell the parent it's done
and then write the output that was read by the parent. Many times the parent would
look for the output before the method wrote it and the test would error. This change
makes the post_run method write out the output before telling the parent it's done.

./tests/test_mixins.py
There was a mismatch in the expected format of the log messages.

./tests/test_mpi_proc.py
This test was really broken including trying to pass a method to the ProcessManager
when the process manager asserts if the argument passed is not derived from Method,
and calling the run() method on ProcessManager that was renamed spawn().

./tests/test_plsel.py
I can't find any selector or pattern code that returns pd.Index ... they all seem to
return MultiIndex. The responses from the tests looked good so I changed the expected
results to MultiIndex.
TODO - this test still fails on test_select_order() 

./tests/test_pm.py
I can't find any selector or pattern code that returns pd.Index ... they all seem to
return MultiIndex. The responses from the tests looked good so I changed the expected
results to MultiIndex.

## TODO - The test_pattern.py and test_lpu.py tests still fail.
