### PR TITLE
Added new module neurokernel.mpi_run

### DIFF
--- a/neurokernel/mpi_run.py
+++ b/neurokernel/mpi_run.py
@@ -1,0 +1,227 @@
+import tempfile
+import os
+import inspect
+import subprocess
+import dill
+import re
+
+from neurokernel.mixins import LoggerMixin
+
+def mpi_run(func, targets=None, delete_tempfile=True, log=False,
+            log_screen=False, log_file_name='neurokernel.log'):
+    """
+    Run a function with mpiexec.
+    
+    Implemented as a fix to 'import neurokernel.mpi_relaunch', which does not
+    work within notebooks. Writes the source code for a function to a temporary
+    file and then runs the temporary file using mpiexec. Returns the stdout of
+    from the function along with a string indicating whether or not the function
+    executed properly.
+
+    Parameters
+    ----------
+    func : function or str
+        Function to be executed with mpiexec. All imports and variables used
+        must be imported or defined within the function. func can either be a callable
+        function or code that represents a valid function.
+    targets : list
+        Dependencies of the manager, such as child classes of the Module class
+        from neurokernel.core_gpu or neurokernel.core.
+    delete_tempfile : bool
+        Whether or not to delete temporary file once func is executed.
+    log : boolean
+        Whether or not to connect to logger for func if logger exists.
+    log_screen : bool
+        Whether or not to send log messages to the screen.
+    log_file_name : str
+        File to send log messages to.
+    
+    Returns
+    -------
+    output : str
+        The stdout from the function run with mpiexec cast to a string.
+
+    Usage
+    -----
+    Does not seem to work with openmpi version 2
+    func should not import neurokernel.mpi_relaunch
+    All modules and variables used must be imported or defined within func
+    Returns the stdout from the function run under 'mpiexec -np 1 python {tmp_file_name}'
+    """
+
+    l = LoggerMixin("mpi_run()",log_on=log)
+    
+    if callable(func):
+        func_text = inspect.getsource(func)
+        # Make a feeble attempt at fixing indentation. Will work for a nested function
+        # that takes no args, not a member function that expects (self) or a class
+        func_text = "\n" + re.sub(r"(^\s+)def ","def ",func_text) + "\n"
+        func_name = func.__name__
+    else: 
+        func_text = "\n" + func + "\n"
+        func_name = re.search('def *(.*)\(\):', func_text).group(1)
+
+    target_text  = "\n"
+    
+    if targets:
+        for t in targets:
+            target_text +=  "\n" + inspect.getsource(t) + "\n"
+
+    main_code  = "\n"
+    main_code += "\nif __name__ == \"__main__\":"
+    main_code += "\n   import neurokernel.mpi as mpi"
+    main_code += "\n   from neurokernel.mixins import LoggerMixin"
+    main_code += "\n   from mpi4py import MPI"
+
+    if log:
+        main_code += "\n   mpi.setup_logger(screen=%s, file_name=\"%s\"," % (log_screen, log_file_name)
+        main_code += "\n                    mpi_comm=MPI.COMM_WORLD, multiline=True)"
+
+    main_code += "\n   l = LoggerMixin(\"%s\",%s)" % (func_name,str(log))
+    main_code += "\n   try:"
+    main_code += "\n      %s()" % func_name
+    main_code += "\n      print(\"MPI_RUN_SUCCESS: %s\")" % func_name
+    main_code += "\n      l.log_info(\"MPI_RUN_SUCCESS: %s\")" % func_name
+    main_code += "\n   except Exception as e:"
+    main_code += "\n      print(\"MPI_RUN_FAILURE: %s\")" % func_name
+    main_code += "\n      l.log_error(\"MPI_RUN_FAILURE: %s\")" % func_name
+    main_code += "\n      print(e)"
+    main_code += "\n"
+
+    try:
+        from mpi4py import MPI
+        #Write code for the function to a temp file
+        temp = tempfile.NamedTemporaryFile(delete = delete_tempfile)
+        temp.write(target_text)
+        temp.write(func_text)
+        temp.write(main_code)
+        temp.flush()
+        
+        #Execute the code
+        #There's a bug in Open MPI v2 that prevents running this with mpiexec. Running 'from mpi4py import MPI' 
+        #does a basic mpi_relaunch which will work for the notebook code, but you give up some of the features 
+        #of mpiexec.
+        if MPI.Get_library_version().startswith("Open MPI v2"):
+            command = ["python", temp.name]
+        else:
+            command = ["mpiexec", "-np", "1", "python", temp.name]
+
+        env = os.environ.copy()
+        l.log_info("Calling: " + " ".join(command))
+        out = subprocess.check_output(command, env = env)
+
+    except Exception as e:
+        l.log_error(str(e))
+        raise
+
+    finally:    
+        #Closing the temp file closes and deletes it
+        temp.close()
+    
+    #Return the output
+    if "MPI_RUN_FAILURE" in out:
+        raise RuntimeError(out)
+
+    return str(out)
+
+
+def mpi_run_manager(man, steps, targets=None, delete_tempfile=True, log=False,
+                    log_screen=False, log_file_name='neurokernel.log'):
+    """
+    Run the manager with mpiexec.
+    
+    Implemented as a fix to 'import neurokernel.mpi_relaunch', which does not work
+    in notebooks. Serializes the manager and sends it to a temporary file, then
+    sends a function to mpi_run, which loads the manager in an mpiexec process and
+    runs it using the common set of commands:
+        man.spawn()
+        man.start(steps = {Number of steps})
+        man.wait()
+    Returns the stdout of from the manager along with a string indicating whether
+    or not the manager ran properly.
+    
+    Parameters
+    ----------
+    man : neurokernel.core_gpu.Manager or neurokernel.core.Manager
+        The Neurokernel manager to be run.
+    steps : int
+        Number of steps to run the manager for.
+    targets : list
+        Dependencies of the manager, such as child classes of the Module class
+        from neurokernel.core_gpu or neurokernel.core.
+    delete_tempfile : bool
+        Whether or not to delete temporary file once the manager is executed.
+    log : boolean
+        Whether or not to connect to logger for manager if logger exists.
+    log_screen : bool
+        Whether or not to send log messages to the screen.
+    log_file_name : str
+        File to send log messages to.
+    
+    Returns
+    -------
+    output : str
+        The stdout from the manager run with mpiexec cast to a string.
+    
+    Usage
+    -----
+    Returns the stdout from the manager 
+    """
+
+    l = LoggerMixin("mpi_run_manager()",log_on=log)
+
+    #Write a function that loads and runs the Manager
+    func_code  = "\ndef MPI_Function():"
+    func_code += "\n    import dill"
+    func_code += "\n    f = open(\"%s\",\"rb\")"
+    func_code += "\n    man = dill.load(f)"
+    func_code += "\n    man.spawn()" 
+    func_code += "\n    man.start(steps=%i)"
+    func_code += "\n    man.wait()"
+
+    try:
+        #Store the Manager in a temporary file
+        temp = tempfile.NamedTemporaryFile(delete = delete_tempfile)
+        dill.dump(man, temp)
+        temp.flush()
+        
+        #Run the function using mpiexec
+        out = mpi_run(func_code % (temp.name,steps), targets, 
+                      delete_tempfile=delete_tempfile, log=log,
+                      log_screen=log_screen, log_file_name=log_file_name)
+
+    except Exception as e:
+        l.log_error(str(e))
+        raise
+
+    finally:    
+        #Closing the temp file closes and deletes it
+        temp.close()
+    
+    #Return the output
+    return str(out)
+
+
+#Basic sanity checks
+if __name__ == "__main__":
+
+    from tools.logging import setup_logger
+    setup_logger(screen=True, file_name='neurokernel.log', multiline=True)
+
+    def _test_success(): 
+        print("HELLO WORLD")
+
+    def _test_fail(): 
+        open("RANDOM_FILE", "r").read() 
+
+    print("This should succeed:")
+    print(mpi_run(_test_success))
+
+    print("This should also succeed:")
+    code  = "\ndef func():"
+    code += "\n   print(\"HELLO AGAIN\")"
+    print(mpi_run(code))
+
+    print("This should fail:")
+    print(mpi_run(_test_fail))
+

--- a/neurokernel/tools/mpi_run.py
+++ b/neurokernel/tools/mpi_run.py
@@ -106,7 +106,12 @@ def mpi_run(func, targets=None, delete_tempfile=True, log=False,
         else:
             command = ["mpiexec", "-np", "1", "python", temp.name]
 
+        # Prevent SLURM from preventing mpiexec from starting multiple processes
         env = os.environ.copy()
+        for k in env.keys():
+            if k.startswith("SLURM"):
+                del env[k]
+        
         l.log_info("Calling: " + " ".join(command))
         out = subprocess.check_output(command, env = env)
 

--- a/tests/test_mpi_run.py
+++ b/tests/test_mpi_run.py
@@ -1,0 +1,194 @@
+#!/usr/bin/env python
+
+#import neurokernel.mpi_relaunch
+import cPickle as pickle
+import os
+import tempfile
+
+from mpi4py import MPI
+import numpy as np
+import pycuda.gpuarray as gpuarray
+
+from neurokernel.pattern import Pattern
+from neurokernel.plsel import Selector, SelectorMethods
+from neurokernel.core_gpu import Module, Manager, CTRL_TAG, GPOT_TAG, SPIKE_TAG
+import neurokernel.mpi as mpi
+from neurokernel.mpi_run import mpi_run,mpi_run_manager
+
+import warnings
+warnings.simplefilter("ignore")
+
+class MyModule1(Module):
+    """
+    Module that emits data.
+    """
+
+    def __init__(self, sel, sel_in, sel_out,
+                 sel_gpot, sel_spike, data_gpot, data_spike,
+                 columns=['interface', 'io', 'type'],
+                 ctrl_tag=CTRL_TAG, gpot_tag=GPOT_TAG, spike_tag=SPIKE_TAG,
+                 id=None, device=None,
+                 routing_table=None, rank_to_id=None,
+                 debug=False, time_sync=False, out_spike_data=None):
+        super(MyModule1, self).__init__(sel, sel_in, sel_out,
+                 sel_gpot, sel_spike, data_gpot, data_spike,
+                 columns,
+                 ctrl_tag, gpot_tag, spike_tag,
+                 id, device,
+                 routing_table, rank_to_id,
+                 debug, time_sync)
+        self.out_spike_data = out_spike_data
+
+    def run_step(self):
+        super(MyModule1, self).run_step()
+
+        # Emit data by setting elements in port map data array corresponding to
+        # output ports:
+        if self.out_spike_data:
+            out_spike_data_gpu = gpuarray.to_gpu(np.asarray(self.out_spike_data,
+                                                        self.data['spike'].dtype))
+            self.pm['spike'][self.out_spike_ports] = out_spike_data_gpu
+            self.log_info('output spike port data: ' + str(out_spike_data_gpu))
+
+class MyModule2(Module):
+    """
+    Module that expects data.
+    """
+
+    def __init__(self, sel, sel_in, sel_out,
+                 sel_gpot, sel_spike, data_gpot, data_spike,
+                 columns=['interface', 'io', 'type'],
+                 ctrl_tag=CTRL_TAG, gpot_tag=GPOT_TAG, spike_tag=SPIKE_TAG,
+                 id=None, device=None,
+                 routing_table=None, rank_to_id=None,
+                 debug=False, time_sync=False, out_file_name=None):
+        super(MyModule2, self).__init__(sel, sel_in, sel_out,
+                 sel_gpot, sel_spike, data_gpot, data_spike,
+                 columns,
+                 ctrl_tag, gpot_tag, spike_tag,
+                 id, device,
+                 routing_table, rank_to_id,
+                 debug, time_sync)
+        self.out_file_name = out_file_name
+            
+    out_buf = []
+
+    def run_step(self):
+        super(MyModule2, self).run_step()
+
+        # Save received data by recording elements in port map data array
+        # corresponding to input ports:
+        in_spike_data = self.pm['spike'][self.in_spike_ports]
+        self.log_info('input spike port data: '+str(in_spike_data))
+        self.out_buf.append(in_spike_data)
+
+    def post_run(self):
+        import cPickle as pickle
+        if self.out_file_name:
+            with open(self.out_file_name, 'w') as f:
+                pickle.dump(self.out_buf[1], f)
+
+        super(MyModule2, self).post_run()
+
+def test_success(): 
+    print("HELLO WORLD")
+
+def make_sels(sel_in_gpot, sel_out_gpot, sel_in_spike, sel_out_spike):
+    sel_in_gpot = Selector(sel_in_gpot)
+    sel_out_gpot = Selector(sel_out_gpot)
+    sel_in_spike = Selector(sel_in_spike)
+    sel_out_spike = Selector(sel_out_spike)
+
+    sel = sel_in_gpot+sel_out_gpot+sel_in_spike+sel_out_spike
+    sel_in = sel_in_gpot+sel_in_spike
+    sel_out = sel_out_gpot+sel_out_spike
+    sel_gpot = sel_in_gpot+sel_out_gpot
+    sel_spike = sel_in_spike+sel_out_spike
+    
+    return sel, sel_in, sel_out, sel_gpot, sel_spike
+
+from unittest import main, TestCase
+
+debug = True
+
+class test_mpi_run(TestCase):
+
+    def test_mpi_run_manager(self):
+        man = Manager()
+        m1_sel_in_gpot = Selector('')
+        m1_sel_out_gpot = Selector('')
+        m1_sel_in_spike = Selector('')
+        m1_sel_out_spike = Selector('/m1/out/spike[0:4]')
+        m1_sel, m1_sel_in, m1_sel_out, m1_sel_gpot, m1_sel_spike = \
+            make_sels(m1_sel_in_gpot, m1_sel_out_gpot, m1_sel_in_spike, m1_sel_out_spike)
+        N1_gpot = SelectorMethods.count_ports(m1_sel_gpot)
+        N1_spike = SelectorMethods.count_ports(m1_sel_spike)
+
+        m2_sel_in_gpot = Selector('')
+        m2_sel_out_gpot = Selector('')
+        m2_sel_in_spike = Selector('/m2/in/spike[0:4]')
+        m2_sel_out_spike = Selector('')
+        m2_sel, m2_sel_in, m2_sel_out, m2_sel_gpot, m2_sel_spike = \
+            make_sels(m2_sel_in_gpot, m2_sel_out_gpot, m2_sel_in_spike, m2_sel_out_spike)
+        N2_gpot = SelectorMethods.count_ports(m2_sel_gpot)
+        N2_spike = SelectorMethods.count_ports(m2_sel_spike)
+
+        m1_id = 'm1'
+        man.add(MyModule1, m1_id,
+                     m1_sel, m1_sel_in, m1_sel_out,
+                     m1_sel_gpot, m1_sel_spike,
+                     np.zeros(N1_gpot, dtype=np.double),
+                     np.zeros(N1_spike, dtype=int),
+                     device=0, debug=debug, out_spike_data=[1, 0, 1, 0])
+
+        f, out_file_name = tempfile.mkstemp()
+        os.close(f)
+
+        m2_id = 'm2'
+        man.add(MyModule2, m2_id,
+                     m2_sel, m2_sel_in, m2_sel_out,
+                     m2_sel_gpot, m2_sel_spike,
+                     np.zeros(N2_gpot, dtype=np.double),
+                     np.zeros(N2_spike, dtype=int),
+                     device=1, debug=debug, out_file_name=out_file_name)
+
+        pat12 = Pattern(m1_sel, m2_sel)
+        pat12.interface[m1_sel_out_gpot] = [0, 'in', 'gpot']
+        pat12.interface[m1_sel_in_gpot] = [0, 'out', 'gpot']
+        pat12.interface[m1_sel_out_spike] = [0, 'in', 'spike']
+        pat12.interface[m1_sel_in_spike] = [0, 'out', 'spike']
+        pat12.interface[m2_sel_in_gpot] = [1, 'out', 'gpot']
+        pat12.interface[m2_sel_out_gpot] = [1, 'in', 'gpot']
+        pat12.interface[m2_sel_in_spike] = [1, 'out', 'spike']
+        pat12.interface[m2_sel_out_spike] = [1, 'in', 'spike']
+        pat12['/m1/out/spike[0]', '/m2/in/spike[0]'] = 1
+        pat12['/m1/out/spike[1]', '/m2/in/spike[1]'] = 1
+        pat12['/m1/out/spike[2]', '/m2/in/spike[2]'] = 1
+        pat12['/m1/out/spike[3]', '/m2/in/spike[3]'] = 1
+        man.connect(m1_id, m2_id, pat12, 0, 1)
+
+        # Run emulation for 2 steps:
+        output = mpi_run_manager(man,2)
+        print(output)
+
+        # Get output of m2:
+        with open(out_file_name, 'r') as f:
+            output = pickle.load(f)
+
+        os.remove(out_file_name)
+        self.assertSequenceEqual(list(output), [1, 0, 1, 0])
+
+    def test_mpi_run(self):
+        output = mpi_run(test_success)
+        self.assertTrue("HELLO WORLD" in output)
+
+    def test_mpi_run_code(self):
+        code  = "\ndef func():"
+        code += "\n   print(\"HELLO AGAIN\")"
+        output = mpi_run(code)
+        self.assertTrue("HELLO AGAIN" in output)
+
+if __name__ == '__main__':
+    logger = mpi.setup_logger(screen=True,
+                              mpi_comm=MPI.COMM_WORLD, multiline=True)
+    main()


### PR DESCRIPTION
Added new module neurokernel.mpi_run. Includes mpi_run, which consumes a function, writes it to a temporary file, and executes it with mpiexec. Also includes mpi_run_manager, which consumes a neurokernel.{core,core_gpu}.Manager and the number of steps to run it, serializes the manager, sends it to a temporary file, writes a function that loads and runs the manager, and feeds the function to mpi_run. The module is primarily for use in notebooks, which cannot run neurokernel.mpi_relaunch.